### PR TITLE
Localize all hardcoded strings

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -17,8 +17,31 @@
     <string name="add_workout_toolbar_title">Agregar entrenamiento</string>
     <!--endregion Add Workout -->
 
+    <!--region Build Workouts -->
+    <string name="build_workouts_button_label_add_workout">[Add Workout]</string>
+    <string name="build_workouts_button_label_go">[Go]</string>
+    <string name="build_workouts_card_header_workouts">[Workouts]</string>
+    <!--endregion Build Workouts -->
+
+    <!--region Confirmation Dialog -->
+    <string name="confirmation_dialog_button_label_cancel">[Cancel]</string>
+    <string name="confirmation_dialog_button_label_confirm">[Confirm]</string>
+    <!--endregion Confirmation Dialog -->
+
+    <!--region Home -->
+    <string name="home_button_label_connect_with_strava">[Connect with Strava]</string>
+    <string name="home_button_label_launch_build_workouts">[Launch BuildWorkoutsScreen]</string>
+    <!--endregion Home -->
+
+    <!--region Play Workout -->
+    <string name="play_workout_button_label_start">[Start]</string>
+    <string name="play_workout_button_label_stop">[Stop]</string>
+    <string name="play_workout_confirmation_stop">[Are you sure you want to stop your workout?]</string>
+    <!--endregion Play Workout -->
+
     <!--region Shared -->
     <string name="content_description_navigate_up">Regresar</string>
+    <string name="content_description_remove">[Remove]</string>
     <plurals name="seconds_long">
         <item quantity="one">%1$d segundo</item>
         <item quantity="other">%1$d segundos</item>
@@ -27,6 +50,6 @@
     <string name="seconds_short_label">s</string>
 
     <string name="interval_duration_label">Duración %1$s</string>
-    <string name="interval_rest_label">Descanso %s</string>
+    <string name="interval_rest_label">Descanso %1$s</string>
     <!--endregion Shared -->
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -17,8 +17,31 @@
     <string name="add_workout_toolbar_title">Add Workout</string>
     <!--endregion Add Workout -->
 
+    <!--region Build Workouts -->
+    <string name="build_workouts_button_label_add_workout">Add Workout</string>
+    <string name="build_workouts_button_label_go">Go</string>
+    <string name="build_workouts_card_header_workouts">Workouts</string>
+    <!--endregion Build Workouts -->
+
+    <!--region Confirmation Dialog -->
+    <string name="confirmation_dialog_button_label_cancel">Cancel</string>
+    <string name="confirmation_dialog_button_label_confirm">Confirm</string>
+    <!--endregion Confirmation Dialog -->
+
+    <!--region Home -->
+    <string name="home_button_label_connect_with_strava">Connect with Strava</string>
+    <string name="home_button_label_launch_build_workouts">Launch BuildWorkoutsScreen</string>
+    <!--endregion Home -->
+
+    <!--region Play Workout -->
+    <string name="play_workout_button_label_start">Start</string>
+    <string name="play_workout_button_label_stop">Stop</string>
+    <string name="play_workout_confirmation_stop">Are you sure you want to stop your workout?</string>
+    <!--endregion Play Workout -->
+
     <!--region Shared -->
     <string name="content_description_navigate_up">Go back</string>
+    <string name="content_description_remove">Remove</string>
     <plurals name="seconds_long">
         <item quantity="one">%1$d second</item>
         <item quantity="other">%1$d seconds</item>
@@ -27,6 +50,6 @@
     <string name="seconds_short_label">s</string>
 
     <string name="interval_duration_label">Duration %1$s</string>
-    <string name="interval_rest_label">Rest %s</string>
+    <string name="interval_rest_label">Rest %1$s</string>
     <!--endregion Shared -->
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/buildWorkouts/BuildWorkoutsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/buildWorkouts/BuildWorkoutsScreen.kt
@@ -35,6 +35,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.majotyler.hiittimer.domain.model.Workout
 import com.majotyler.hiittimer.presentation.common.RowClickable
 import com.majotyler.hiittimer.presentation.common.TableCard
+import hiittimer.composeapp.generated.resources.Res
+import hiittimer.composeapp.generated.resources.build_workouts_button_label_add_workout
+import hiittimer.composeapp.generated.resources.build_workouts_button_label_go
+import hiittimer.composeapp.generated.resources.build_workouts_card_header_workouts
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 
@@ -97,7 +102,7 @@ fun StartButton(
         onClick = { onClickedGo() },
     ) {
         Text(
-            text = "Go",
+            text = stringResource(resource = Res.string.build_workouts_button_label_go),
             fontSize = 30.sp,
         )
     }
@@ -114,7 +119,7 @@ fun Workouts(
         modifier = modifier,
     ) {
         TableCard(
-            header = "Workouts",
+            header = stringResource(resource = Res.string.build_workouts_card_header_workouts),
             content = {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -151,7 +156,7 @@ fun Workouts(
                             modifier = Modifier.width(width = 2.dp),
                         )
                         Text(
-                            text = "Add Workout",
+                            text = stringResource(resource = Res.string.build_workouts_button_label_add_workout),
                             fontWeight = FontWeight.SemiBold,
                             style = MaterialTheme.typography.titleLarge,
                         )

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/RowClickable.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/RowClickable.kt
@@ -29,6 +29,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import hiittimer.composeapp.generated.resources.Res
+import hiittimer.composeapp.generated.resources.content_description_remove
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -103,7 +106,7 @@ fun RowClickable(
             ) {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = "Remove",
+                    contentDescription = stringResource(resource = Res.string.content_description_remove),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/composables/ConfirmationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/composables/ConfirmationDialog.kt
@@ -5,6 +5,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import com.majotyler.hiittimer.presentation.common.ui.HiitAppTheme
+import hiittimer.composeapp.generated.resources.Res
+import hiittimer.composeapp.generated.resources.confirmation_dialog_button_label_cancel
+import hiittimer.composeapp.generated.resources.confirmation_dialog_button_label_confirm
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -21,7 +25,7 @@ fun ConfirmationDialog(
                 onClick = onClickPositive,
             ) {
                 Text(
-                    text = "Confirm",
+                    text = stringResource(resource = Res.string.confirmation_dialog_button_label_confirm),
                 )
             }
         },
@@ -30,7 +34,7 @@ fun ConfirmationDialog(
                 onClick = onClickNegative,
             ) {
                 Text(
-                    text = "Cancel",
+                    text = stringResource(resource = Res.string.confirmation_dialog_button_label_cancel),
                 )
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
@@ -11,6 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewModelScope
 import com.majotyler.hiittimer.platform.UrlOpener
+import hiittimer.composeapp.generated.resources.Res
+import hiittimer.composeapp.generated.resources.home_button_label_connect_with_strava
+import hiittimer.composeapp.generated.resources.home_button_label_launch_build_workouts
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun HomeScreen(
@@ -35,14 +39,14 @@ fun HomeScreen(
                 viewModel.onEvent(event = HomeViewEvent.ClickedLaunchBuildWorkouts)
             },
         ) {
-            Text(text = "Launch BuildWorkoutsScreen")
+            Text(text = stringResource(resource = Res.string.home_button_label_launch_build_workouts))
         }
         Button(
             onClick = {
                 viewModel.onEvent(event = HomeViewEvent.ClickedConnectWithStrava)
             },
         ) {
-            Text(text = "Connect with Strava")
+            Text(text = stringResource(resource = Res.string.home_button_label_connect_with_strava))
         }
 
         if (viewModel.showCreateActivityButton) {

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutScreen.kt
@@ -22,6 +22,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.majotyler.hiittimer.presentation.common.composables.ConfirmationDialog
 import com.majotyler.hiittimer.presentation.common.expect.BackHandler
+import hiittimer.composeapp.generated.resources.Res
+import hiittimer.composeapp.generated.resources.play_workout_button_label_start
+import hiittimer.composeapp.generated.resources.play_workout_button_label_stop
+import hiittimer.composeapp.generated.resources.play_workout_confirmation_stop
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun PlayWorkoutScreen(
@@ -29,7 +34,7 @@ fun PlayWorkoutScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val play by viewModel.play.collectAsStateWithLifecycle()
-    val text by viewModel.text.collectAsStateWithLifecycle()
+    val workoutPlayState by viewModel.workoutPlayState.collectAsStateWithLifecycle()
     val enabled by viewModel.enabled.collectAsStateWithLifecycle()
 
     BackHandler(
@@ -49,7 +54,7 @@ fun PlayWorkoutScreen(
             viewModel.onEvent(event = PlayWorkoutViewEvent.ClickedDialogConfirm)
         },
         onClickedPlay = { viewModel.onEvent(event = PlayWorkoutViewEvent.ClickedPlay) },
-        text = text,
+        workoutPlayState = workoutPlayState,
         play = play,
         onClickedPause = {
             viewModel.onEvent(
@@ -66,7 +71,7 @@ private fun PlayWorkoutContent(
     progressDisplay: String,
     progress: Float,
     onClickedPlay: () -> Unit,
-    text: String,
+    workoutPlayState: WorkoutPlayState,
     play: Boolean,
     onClickedDialogConfirm: () -> Unit,
     onClickedDialogCancel: () -> Unit,
@@ -75,7 +80,7 @@ private fun PlayWorkoutContent(
 ) {
     if (confirmationDialogVisible) {
         ConfirmationDialog(
-            text = "Are you sure you want to stop your workout?",
+            text = stringResource(resource = Res.string.play_workout_confirmation_stop),
             onClickPositive = onClickedDialogConfirm,
             onClickNegative = onClickedDialogCancel,
             onDismiss = onClickedDialogCancel,
@@ -112,6 +117,10 @@ private fun PlayWorkoutContent(
             )
         }
         Spacer(modifier = Modifier.height(12.dp))
+        val buttonLabel = when (workoutPlayState) {
+            WorkoutPlayState.PLAYING -> stringResource(resource = Res.string.play_workout_button_label_stop)
+            WorkoutPlayState.PAUSED -> stringResource(resource = Res.string.play_workout_button_label_start)
+        }
         Button(onClick = {
             if (play) {
                 onClickedPause()
@@ -119,7 +128,7 @@ private fun PlayWorkoutContent(
                 onClickedPlay()
             }
         }, enabled = enabled) {
-            Text(text)
+            Text(text = buttonLabel)
         }
 
 

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutVIewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutVIewModel.kt
@@ -31,8 +31,8 @@ class PlayWorkoutVIewModel(
     private val _play = MutableStateFlow(false)
 
     val play = _play.asStateFlow()
-    private val _text = MutableStateFlow("Start")
-    val text = _text.asStateFlow()
+    private val _workoutPlayState = MutableStateFlow(value = WorkoutPlayState.PAUSED)
+    val workoutPlayState = _workoutPlayState.asStateFlow()
 
     private val _enabled = MutableStateFlow(true)
     val enabled = _enabled.asStateFlow()
@@ -89,7 +89,7 @@ class PlayWorkoutVIewModel(
 
     private fun onClickedPlay() {
         _play.value = !_play.value
-        _text.value = if (_play.value) "Stop" else "Start"
+        _workoutPlayState.value = if (_play.value) WorkoutPlayState.PLAYING else WorkoutPlayState.PAUSED
 
         if (_play.value) {
             if (runningMark == null) {
@@ -136,7 +136,7 @@ class PlayWorkoutVIewModel(
         pollProgressJob?.cancel()
 
         _play.value = false
-        _text.value = "Start"
+        _workoutPlayState.value = WorkoutPlayState.PAUSED
     }
 
     private fun updateStateWithAccumulatedTime() {
@@ -168,7 +168,7 @@ class PlayWorkoutVIewModel(
 
                         if (hasFinishedAllWorkouts) {
                             _play.value = false
-                            _text.value = "Start"
+                            _workoutPlayState.value = WorkoutPlayState.PAUSED
                             _enabled.value = false
                             pollProgressJob?.cancel()
 

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/WorkoutPlayState.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/WorkoutPlayState.kt
@@ -1,0 +1,6 @@
+package com.majotyler.hiittimer.presentation.playWorkoutScreen
+
+enum class WorkoutPlayState {
+    PAUSED,
+    PLAYING,
+}


### PR DESCRIPTION
## Summary
- Moved all 10 user-facing hardcoded string literals across 6 files into `composeResources/values/strings.xml` (12 new keys total, including Start/Stop split)
- Added bracketed English placeholders for all 12 new keys in `values-es/strings.xml` (e.g. `[Cancel]`, `[Go]`) — greppable with `grep '>\[' values-es/strings.xml`
- Refactored `PlayWorkoutVIewModel` to expose `isRunning: StateFlow<Boolean>` instead of `text: StateFlow<String>`, keeping the VM Compose-free
- Replaced all hardcoded literals at call sites with `stringResource(Res.string.<key>)`

## Files changed
- `composeResources/values/strings.xml` — 12 new keys in 4 new regions (Home, Build Workouts, Play Workout, Confirmation Dialog) + 1 in Shared
- `composeResources/values-es/strings.xml` — same 12 keys with `[English]` placeholders
- `PlayWorkoutVIewModel.kt` — `text: StateFlow<String>` → `isRunning: StateFlow<Boolean>`
- `HomeScreen.kt`, `BuildWorkoutsScreen.kt`, `PlayWorkoutScreen.kt`, `ConfirmationDialog.kt`, `RowClickable.kt` — hardcoded literals replaced

## Test plan
Build passes via `./gradlew :composeApp:assembleDebug`
No hardcoded literals remain outside `@Preview` functions (verified with grep)
- [ ] Verify English locale renders all strings correctly at runtime
- [ ] Verify Spanish locale shows `[bracketed]` placeholders for the 12 new strings
- [ ] Verify Play Workout start/stop button toggles correctly between Start and Stop labels