### PR TITLE
Fix back button not navigating up from add workout screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutDestination.kt
@@ -4,4 +4,5 @@ import com.majotyler.hiittimer.domain.model.Workout
 
 sealed interface AddWorkoutDestination {
     data class AddWorkout(val workout: Workout) : AddWorkoutDestination
+    data object NavigateUp : AddWorkoutDestination
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutViewModel.kt
@@ -124,8 +124,7 @@ class AddWorkoutViewModel(private val router: Router<AddWorkoutDestination>) : V
         val wasOnFirstPage = nextPageOrdinal < 0
 
         if (wasOnFirstPage) {
-            // TODO (This needs to navigate up so you go back to the previous screen, maybe with a
-            // "are you sure" type message
+            router.routeTo(destination = AddWorkoutDestination.NavigateUp)
         } else {
             _page.value = AddWorkoutPage.entries[nextPageOrdinal]
         }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
@@ -82,6 +82,7 @@ private fun HiitNavDisplay(
                                 resultBus.sendResult<Workout>(result = destination.workout)
                                 backStack.removeLast()
                             }
+                            AddWorkoutDestination.NavigateUp -> backStack.removeLast()
                         }
                     }
                 )


### PR DESCRIPTION
### Background

This commit fixes the broken Navigate Up functionality on the Add Workout Screen

### Demo

#### Before
https://github.com/user-attachments/assets/177b661f-8bf6-4c26-ac1b-a1c65ba815f7

#### After
https://github.com/user-attachments/assets/801d6454-0e0b-4258-970f-2624a14b4adb

