### PR TITLE
Add Workout improvements and bug fixes

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -27,6 +27,6 @@
     <string name="seconds_short_label">s</string>
 
     <string name="interval_duration_label">Duración %1$s</string>
-    <string name="interval_rest_label">Descanso %s</string>
+    <string name="interval_rest_label">Descanso %1$s</string>
     <!--endregion Shared -->
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -27,6 +27,6 @@
     <string name="seconds_short_label">s</string>
 
     <string name="interval_duration_label">Duration %1$s</string>
-    <string name="interval_rest_label">Rest %s</string>
+    <string name="interval_rest_label">Rest %1$s</string>
     <!--endregion Shared -->
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.majotyler.hiittimer.domain.model.Interval
 import com.majotyler.hiittimer.presentation.common.RowClickable
 import com.majotyler.hiittimer.presentation.common.TableCard
+import com.majotyler.hiittimer.presentation.common.expect.BackHandler
 import com.majotyler.hiittimer.presentation.common.ui.HiitAppTheme
 import hiittimer.composeapp.generated.resources.Res
 import hiittimer.composeapp.generated.resources.add_workout_add_interval_button_label_add_interval
@@ -160,6 +161,8 @@ private fun CreateWorkoutScreenContent(
     onClickedBottomBarButton: () -> Unit,
     onClickedNavigateUp: () -> Unit,
 ) {
+    BackHandler(onBack = onClickedNavigateUp)
+
     Scaffold(
         modifier = Modifier.imePadding(),
         topBar = {

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/addWorkoutScreen/AddWorkoutScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -34,6 +35,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.majotyler.hiittimer.domain.model.Interval
@@ -158,6 +161,7 @@ private fun CreateWorkoutScreenContent(
     onClickedNavigateUp: () -> Unit,
 ) {
     Scaffold(
+        modifier = Modifier.imePadding(),
         topBar = {
             TopAppBar(
                 title = {
@@ -321,6 +325,7 @@ private fun ColumnScope.CreateWorkoutPageAddIntervals(
                     ),
                 )
             },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             value = secondsDuration.toString(),
             onValueChange = { onIntervalDurationChanged(it) },
             modifier = Modifier.weight(weight = 1F),
@@ -342,6 +347,7 @@ private fun ColumnScope.CreateWorkoutPageAddIntervals(
                     ),
                 )
             },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             value = secondsRest.toString(),
             onValueChange = { onIntervalRestChanged(it) },
             modifier = Modifier.weight(weight = 1F),


### PR DESCRIPTION
### Summary

This commit introduces various UI improvements and fixes to the Add Workout screen.

### Changes

* Fix rest seconds not being properly formatted.
* Fix native back-press not being handled, which resulted in clicking it exiting Add Workout always, when we instead want to simply "go-up" a step if possible.
* Improve Keyboard UX by adding padding such that when the keyboard opens it does not cover the button at the bottom. Also make sure the numbers can only take numbers, not text.