### PR TITLE
Fix timer ignoring workout repetitions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutVIewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/playWorkoutScreen/PlayWorkoutVIewModel.kt
@@ -60,6 +60,9 @@ class PlayWorkoutVIewModel(
     private val currentWorkoutInterval: Interval?
         get() = currentWorkout?.intervals?.getOrNull(index = currentWorkoutIntervalIndex)
 
+    /** Tracks how many times the current workout's intervals have been repeated (0-based). */
+    private var currentWorkoutRepetitionIndex: Int = 0
+
     private var pollProgressJob: Job? = null
     private var runningMark: TimeMark? = null
 
@@ -164,14 +167,34 @@ class PlayWorkoutVIewModel(
                             currentWorkoutIntervalState == PlayWorkoutStateOfInterval.RESTING
                         val currentIntervalIsLastInWorkout =
                             currentWorkoutIntervalIndex == lastIndexOfIntervalsInCurrentWorkout
-                        val hasFinishedAllWorkouts = isResting && currentIntervalIsLastInWorkout
+                        val hasFinishedCurrentWorkoutCycle = isResting && currentIntervalIsLastInWorkout
 
-                        if (hasFinishedAllWorkouts) {
-                            _play.value = false
-                            _text.value = "Start"
-                            _enabled.value = false
-                            pollProgressJob?.cancel()
+                        if (hasFinishedCurrentWorkoutCycle) {
+                            val totalRepetitions = currentWorkout?.repetitions ?: 1
+                            val hasMoreRepetitions = currentWorkoutRepetitionIndex < totalRepetitions - 1
+                            val isLastWorkout = currentWorkoutIndex == workouts.lastIndex
 
+                            when {
+                                hasMoreRepetitions -> {
+                                    currentWorkoutRepetitionIndex++
+                                    currentWorkoutIntervalIndex = 0
+                                    currentWorkoutIntervalState = PlayWorkoutStateOfInterval.EXERCISING
+                                    currentStepProgressMs = 0L
+                                }
+                                !isLastWorkout -> {
+                                    currentWorkoutRepetitionIndex = 0
+                                    currentWorkoutIndex++
+                                    currentWorkoutIntervalIndex = 0
+                                    currentWorkoutIntervalState = PlayWorkoutStateOfInterval.EXERCISING
+                                    currentStepProgressMs = 0L
+                                }
+                                else -> {
+                                    _play.value = false
+                                    _text.value = "Start"
+                                    _enabled.value = false
+                                    pollProgressJob?.cancel()
+                                }
+                            }
                         } else {
                             nextStep()
                         }


### PR DESCRIPTION
## Summary

- El campo `repetitions` de `Workout` no se leía en el timer
- Al terminar el último intervalo el cronómetro paraba en lugar de reiniciar los intervalos N veces
- También avanza al siguiente workout al terminar las repeticiones del actual

## Test plan
- [ ] Workout con repetitions > 1: verificar que los intervalos se repiten N veces
- [ ] Workout con repetitions = 1: verificar que el comportamiento no cambió
- [ ] Múltiples workouts: verificar que el timer avanza al siguiente al terminar las repeticiones del primero

🤖 Generated with [Claude Code](https://claude.com/claude-code)