### PR TITLE
Route Strava OAuth token exchange through Cloudflare Worker proxy

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/MainActivity.kt
@@ -15,16 +15,15 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val uri: Uri? = intent?.data
-        val accessToken: String? = uri?.getQueryParameter("code")
+        val accessCode: String? = uri?.getQueryParameter("code")
 
-        // TODO we need to use this to make a Strava Activity
-        println("Access token is $accessToken")
+        println("Strava access code: $accessCode")
 
         setContent {
             MaterialTheme {
                 NavigationRoot(
                     urlOpener = AndroidUrlOpener(context = this),
-                    stravaAccessToken = accessToken,
+                    stravaAccessCode = accessCode,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
@@ -5,24 +5,23 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.header
-import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Parameters
+import io.ktor.http.contentType
 
 class StravaApi(private val client: HttpClient) {
-    suspend fun getAccessToken(
-        clientId: Int,
-        clientSecret: String,
+    suspend fun getAccessTokenViaProxy(
         code: String,
     ): StravaAuthenticationDto {
-        return client.post(urlString = StravaEndpoints.OAUTH_TOKEN) {
-            parameter(key = "client_id", value = clientId)
-            parameter(key = "client_secret", value = clientSecret)
-            parameter(key = "code", value = code)
-            parameter(key = "grant_type", value = StravaGrantTypes.AUTH_CODE)
-        }.body()
+        val response = client.post(urlString = ProxyEndpoints.OAUTH_TOKEN) {
+            contentType(ContentType.Application.Json)
+            setBody(mapOf("code" to code))
+        }
+        println("Proxy token exchange status: ${response.status}")
+        return response.body()
     }
 
     suspend fun createActivity(
@@ -50,10 +49,9 @@ class StravaApi(private val client: HttpClient) {
 
 private object StravaEndpoints {
     const val BASE_URL = "https://www.strava.com"
-    const val OAUTH_TOKEN = "$BASE_URL/oauth/token"
     const val ACTIVITIES = "$BASE_URL/api/v3/activities"
 }
 
-private object StravaGrantTypes {
-    const val AUTH_CODE = "authorization_code"
+private object ProxyEndpoints {
+    const val OAUTH_TOKEN = "https://strava-token-proxy.hiit-timer-app.workers.dev"
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/dto/StravaAuthenticationDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/dto/StravaAuthenticationDto.kt
@@ -5,14 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class StravaAuthenticationDto(
-    @SerialName("token_type")
-    val tokenType: String,
-    @SerialName("expires_at")
-    val expiresAt: Long,
-    @SerialName("expires_in")
-    val expiresIn: Int,
-    @SerialName("refresh_token")
-    val refreshToken: String,
-    @SerialName("access_token")
-    val accessToken: String,
+    @SerialName("token")
+    val encryptedToken: String,
 )

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
@@ -2,7 +2,6 @@ package com.majotyler.hiittimer.data.repository
 
 import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.dto.StravaAuthenticationDto
-import com.majotyler.hiittimer.network.StravaClientSecret
 
 class StravaRepository(
     private val api: StravaApi
@@ -10,11 +9,7 @@ class StravaRepository(
     suspend fun getAccessToken(
         code: String,
     ): StravaAuthenticationDto {
-        return api.getAccessToken(
-            clientId = StravaClientSecret.STRAVA_CLIENT_ID,
-            clientSecret = StravaClientSecret.STRAVA_CLIENT_SECRET,
-            code = code,
-        )
+        return api.getAccessTokenViaProxy(code = code)
     }
 
     suspend fun createActivity(

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
@@ -1,33 +1,7 @@
 package com.majotyler.hiittimer.domain.usecase
 
-import com.majotyler.hiittimer.data.repository.StravaRepository
-import com.majotyler.hiittimer.network.StravaClientSecret
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.ExperimentalTime
-
-class CreateStravaActivityUseCase(
-    private val stravaAccessCode: String,
-    private val repository: StravaRepository,
-) {
-    @OptIn(ExperimentalTime::class)
+class CreateStravaActivityUseCase {
     suspend operator fun invoke() {
-        val accessToken = repository.getAccessToken(code = stravaAccessCode)
-
-        repository.createActivity(
-            accessToken = accessToken.accessToken,
-            name = "Created from HIIT App",
-            type = "HighIntensityIntervalTraining",
-            startDateLocal = TimeZone.currentSystemDefault()
-                .let { tz ->
-                    Clock.System.now()
-                        .minus(1.hours)
-                        .toLocalDateTime(tz)
-                        .toString()
-                },
-            elapsedTime = 60,
-        )
+        // TODO: createActivity needs to move to the worker once full proxy is built
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
@@ -33,12 +33,12 @@ import kotlin.uuid.Uuid
 @Composable
 fun NavigationRoot(
     urlOpener: UrlOpener,
-    stravaAccessToken: String?,
+    stravaAccessCode: String?,
 ) {
     HiitAppTheme {
         HiitNavDisplay(
             urlOpener = urlOpener,
-            stravaAccessToken = stravaAccessToken,
+            stravaAccessCode = stravaAccessCode,
         )
     }
 }
@@ -47,7 +47,7 @@ fun NavigationRoot(
 @Composable
 private fun HiitNavDisplay(
     urlOpener: UrlOpener,
-    stravaAccessToken: String?,
+    stravaAccessCode: String?,
 ) {
 
     val resultBus = remember { ResultEventBus() }
@@ -106,7 +106,7 @@ private fun HiitNavDisplay(
                             }
                         }
                     },
-                    stravaAccessToken = stravaAccessToken,
+                    stravaAccessCode = stravaAccessCode,
                 )
 
                 HomeScreen(

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
@@ -1,8 +1,8 @@
 package com.majotyler.hiittimer.presentation.homeScreen
 
 import androidx.lifecycle.ViewModel
-import io.ktor.http.*
 import androidx.lifecycle.viewModelScope
+import io.ktor.http.*
 import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
@@ -35,10 +35,20 @@ class HomeViewModel(
         StravaRepository(stravaApi)
     }
     private val createStravaActivityUseCase by lazy {
-        CreateStravaActivityUseCase(
-            stravaAccessCode = stravaAccessCode ?: "",
-            repository = stravaRepository,
-        )
+        CreateStravaActivityUseCase()
+    }
+
+    init {
+        if (stravaAccessCode != null) {
+            viewModelScope.launch {
+                try {
+                    val result = stravaRepository.getAccessToken(code = stravaAccessCode)
+                    println("Encrypted token: ${result.encryptedToken}")
+                } catch (e: Exception) {
+                    println("Token exchange error: $e")
+                }
+            }
+        }
     }
 
     fun onEvent(event: HomeViewEvent) {
@@ -50,7 +60,6 @@ class HomeViewModel(
     }
 
     private fun onClickedConnectWithStrava() {
-
         viewModelScope.launch {
             _openUrl.emit(value = getAuthUri())
         }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
@@ -7,12 +7,12 @@ import kotlin.reflect.KClass
 
 class HomeViewModelFactory(
     private val router: (HomeDestination) -> Unit,
-    private val stravaAccessToken: String?,
+    private val stravaAccessCode: String?,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
         return HomeViewModel(
             router = router,
-            stravaAccessCode = stravaAccessToken,
+            stravaAccessCode = stravaAccessCode,
         ) as T
     }
 }


### PR DESCRIPTION
## Background

We are using the Strava API. To use it, on every request, we need to include a "client secret" and a "client ID". The "client ID" is short, just a couple numbers. It isn't intended to be secure. The "client secret" is long, 40 characters, and the point of it is that only we have control of it. Nobody else can see it. If it is compromised, it's a biiiiiig problem, because, among other reasons, anytime you use an API you limits. Sometimes, you pay to use the API. People could steal the secret, and use the API a lot and you end up paying thousands of dollars. Or, they could use the secret to get information that is dangerous.

The worst we could do is make our public repository have a field like `val clientSecret = "xxxxxxx"`. Obviously, that is just giving it to everyone.

An improvement we did was to put those in a `.gitignore` file. This way, you can't get the clientSecret.

This has two problems still:
* It is a PITA (pain in the ass) because you have to have anyone working in your repository manually paste it in.
* It isn't secure if someone decompiles your application because they can see all of the hard-coded values.

A next step to improve this, is if the client secret lived remotely, on some server somewhere.

This commit implements that.