### PR TITLE
Store encrypted Strava tokens in Android Keystore

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.androidx.security.crypto)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
+import com.majotyler.hiittimer.data.repository.AndroidStravaTokenStorageRepository
 import com.majotyler.hiittimer.presentation.common.navigation.NavigationRoot
 import com.majotyler.hiittimer.presentation.platform.AndroidUrlOpener
 
@@ -19,11 +20,14 @@ class MainActivity : ComponentActivity() {
 
         println("Strava access code: $accessCode")
 
+        val stravaTokenStorageRepository = AndroidStravaTokenStorageRepository(context = this)
+
         setContent {
             MaterialTheme {
                 NavigationRoot(
                     urlOpener = AndroidUrlOpener(context = this),
                     stravaAccessCode = accessCode,
+                    stravaTokenStorageRepository = stravaTokenStorageRepository,
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/data/repository/AndroidStravaTokenStorageRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/majotyler/hiittimer/data/repository/AndroidStravaTokenStorageRepository.kt
@@ -1,0 +1,44 @@
+package com.majotyler.hiittimer.data.repository
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.majotyler.hiittimer.data.model.StoredStravaToken
+
+class AndroidStravaTokenStorageRepository(context: Context) : StravaTokenStorageRepository {
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        FILE_NAME,
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    override suspend fun getStoredToken(): StoredStravaToken? {
+        val accessToken = prefs.getString(KEY_ACCESS_TOKEN, null) ?: return null
+        val refreshToken = prefs.getString(KEY_REFRESH_TOKEN, null) ?: return null
+        val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
+        return StoredStravaToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            expiresAt = expiresAt,
+        )
+    }
+
+    override suspend fun saveToken(accessToken: String, refreshToken: String, expiresAt: Long) {
+        prefs.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_REFRESH_TOKEN, refreshToken)
+            .putLong(KEY_EXPIRES_AT, expiresAt)
+            .apply()
+        println("Strava tokens saved to storage")
+    }
+
+    private companion object {
+        const val FILE_NAME = "strava_token_storage"
+        const val KEY_ACCESS_TOKEN = "access_token"
+        const val KEY_REFRESH_TOKEN = "refresh_token"
+        const val KEY_EXPIRES_AT = "expires_at"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
@@ -24,6 +24,17 @@ class StravaApi(private val client: HttpClient) {
         return response.body()
     }
 
+    suspend fun refreshAccessTokenViaProxy(
+        refreshToken: String,
+    ): StravaAuthenticationDto {
+        val response = client.post(urlString = ProxyEndpoints.OAUTH_REFRESH) {
+            contentType(ContentType.Application.Json)
+            setBody(mapOf("refresh_token" to refreshToken))
+        }
+        println("Proxy token refresh status: ${response.status}")
+        return response.body()
+    }
+
     suspend fun createActivity(
         accessToken: String,
         name: String,
@@ -53,5 +64,7 @@ private object StravaEndpoints {
 }
 
 private object ProxyEndpoints {
-    const val OAUTH_TOKEN = "https://strava-token-proxy.hiit-timer-app.workers.dev"
+    const val BASE_URL = "https://strava-token-proxy.hiit-timer-app.workers.dev"
+    const val OAUTH_TOKEN = BASE_URL
+    const val OAUTH_REFRESH = "$BASE_URL/refresh"
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
@@ -3,68 +3,69 @@ package com.majotyler.hiittimer.data.api
 import com.majotyler.hiittimer.data.dto.StravaAuthenticationDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.forms.FormDataContent
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.Parameters
 import io.ktor.http.contentType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 class StravaApi(private val client: HttpClient) {
-    suspend fun getAccessTokenViaProxy(
+    suspend fun getAccessToken(
         code: String,
     ): StravaAuthenticationDto {
-        val response = client.post(urlString = ProxyEndpoints.OAUTH_TOKEN) {
+        val response = client.post(urlString = Endpoints.OAUTH_TOKEN) {
             contentType(ContentType.Application.Json)
             setBody(mapOf("code" to code))
         }
-        println("Proxy token exchange status: ${response.status}")
+        println("Token exchange status: ${response.status}")
         return response.body()
     }
 
-    suspend fun refreshAccessTokenViaProxy(
+    suspend fun refreshAccessToken(
         refreshToken: String,
     ): StravaAuthenticationDto {
-        val response = client.post(urlString = ProxyEndpoints.OAUTH_REFRESH) {
+        val response = client.post(urlString = Endpoints.OAUTH_REFRESH) {
             contentType(ContentType.Application.Json)
             setBody(mapOf("refresh_token" to refreshToken))
         }
-        println("Proxy token refresh status: ${response.status}")
+        println("Token refresh status: ${response.status}")
         return response.body()
     }
 
     suspend fun createActivity(
         accessToken: String,
         name: String,
-        type: String,
+        sportType: String,
         startDateLocal: String,
         elapsedTime: Int,
     ) {
-        return client.post(urlString = StravaEndpoints.ACTIVITIES) {
-            header(key = HttpHeaders.Authorization, value = "Bearer $accessToken")
-            setBody(
-                body = FormDataContent(
-                    formData = Parameters.build {
-                        append(name = "name", value = name)
-                        append(name = "sport_type", value = type)
-                        append(name = "start_date_local", value = startDateLocal)
-                        append(name = "elapsed_time", value = elapsedTime.toString())
-                    }
-                )
-            )
-        }.body()
+        val response = client.post(urlString = Endpoints.CREATE_ACTIVITY) {
+            contentType(ContentType.Application.Json)
+            setBody(CreateActivityRequest(
+                accessToken = accessToken,
+                name = name,
+                sportType = sportType,
+                startDateLocal = startDateLocal,
+                elapsedTime = elapsedTime,
+            ))
+        }
+        println("Create activity status: ${response.status}")
     }
 }
 
-private object StravaEndpoints {
-    const val BASE_URL = "https://www.strava.com"
-    const val ACTIVITIES = "$BASE_URL/api/v3/activities"
-}
+@Serializable
+private data class CreateActivityRequest(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("name") val name: String,
+    @SerialName("sport_type") val sportType: String,
+    @SerialName("start_date_local") val startDateLocal: String,
+    @SerialName("elapsed_time") val elapsedTime: Int,
+)
 
-private object ProxyEndpoints {
+private object Endpoints {
     const val BASE_URL = "https://strava-token-proxy.hiit-timer-app.workers.dev"
     const val OAUTH_TOKEN = BASE_URL
     const val OAUTH_REFRESH = "$BASE_URL/refresh"
+    const val CREATE_ACTIVITY = "$BASE_URL/activity"
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/model/StoredStravaToken.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/model/StoredStravaToken.kt
@@ -1,0 +1,7 @@
+package com.majotyler.hiittimer.data.model
+
+data class StoredStravaToken(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresAt: Long,
+)

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
@@ -9,22 +9,28 @@ class StravaRepository(
     suspend fun getAccessToken(
         code: String,
     ): StravaAuthenticationDto {
-        return api.getAccessTokenViaProxy(code = code)
+        return api.getAccessToken(code = code)
     }
 
     suspend fun refreshAccessToken(
         refreshToken: String,
     ): StravaAuthenticationDto {
-        return api.refreshAccessTokenViaProxy(refreshToken = refreshToken)
+        return api.refreshAccessToken(refreshToken = refreshToken)
     }
 
     suspend fun createActivity(
         accessToken: String,
         name: String,
-        type: String,
+        sportType: String,
         startDateLocal: String,
         elapsedTime: Int,
     ) {
-        return api.createActivity(accessToken, name, type, startDateLocal, elapsedTime)
+        api.createActivity(
+            accessToken = accessToken,
+            name = name,
+            sportType = sportType,
+            startDateLocal = startDateLocal,
+            elapsedTime = elapsedTime,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
@@ -12,6 +12,12 @@ class StravaRepository(
         return api.getAccessTokenViaProxy(code = code)
     }
 
+    suspend fun refreshAccessToken(
+        refreshToken: String,
+    ): StravaAuthenticationDto {
+        return api.refreshAccessTokenViaProxy(refreshToken = refreshToken)
+    }
+
     suspend fun createActivity(
         accessToken: String,
         name: String,

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaTokenStorageRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaTokenStorageRepository.kt
@@ -1,0 +1,8 @@
+package com.majotyler.hiittimer.data.repository
+
+import com.majotyler.hiittimer.data.model.StoredStravaToken
+
+interface StravaTokenStorageRepository {
+    suspend fun getStoredToken(): StoredStravaToken?
+    suspend fun saveToken(accessToken: String, refreshToken: String, expiresAt: Long)
+}

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
@@ -1,7 +1,26 @@
 package com.majotyler.hiittimer.domain.usecase
 
-class CreateStravaActivityUseCase {
-    suspend operator fun invoke() {
-        // TODO: createActivity needs to move to the worker once full proxy is built
+import com.majotyler.hiittimer.data.repository.StravaRepository
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+
+class CreateStravaActivityUseCase(
+    private val stravaRepository: StravaRepository,
+    private val stravaTokenStorageRepository: StravaTokenStorageRepository,
+) {
+    suspend operator fun invoke(
+        name: String,
+        sportType: String,
+        startDateLocal: String,
+        elapsedTime: Int,
+    ) {
+        val token = stravaTokenStorageRepository.getStoredToken()
+            ?: error("No stored Strava token")
+        stravaRepository.createActivity(
+            accessToken = token.accessToken,
+            name = name,
+            sportType = sportType,
+            startDateLocal = startDateLocal,
+            elapsedTime = elapsedTime,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/GetStoredStravaTokenUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/GetStoredStravaTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.majotyler.hiittimer.domain.usecase
+
+import com.majotyler.hiittimer.data.model.StoredStravaToken
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+
+class GetStoredStravaTokenUseCase(
+    private val repository: StravaTokenStorageRepository,
+) {
+    suspend operator fun invoke(): StoredStravaToken? = repository.getStoredToken()
+}

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/RefreshStravaTokenUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/RefreshStravaTokenUseCase.kt
@@ -1,0 +1,20 @@
+package com.majotyler.hiittimer.domain.usecase
+
+import com.majotyler.hiittimer.data.repository.StravaRepository
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+
+class RefreshStravaTokenUseCase(
+    private val stravaRepository: StravaRepository,
+    private val stravaTokenStorageRepository: StravaTokenStorageRepository,
+) {
+    suspend operator fun invoke(refreshToken: String) {
+        val result = stravaRepository.refreshAccessToken(
+            refreshToken = refreshToken,
+        )
+        stravaTokenStorageRepository.saveToken(
+            accessToken = result.accessToken,
+            refreshToken = result.refreshToken,
+            expiresAt = result.expiresAt,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/SaveStravaTokenUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/SaveStravaTokenUseCase.kt
@@ -1,0 +1,15 @@
+package com.majotyler.hiittimer.domain.usecase
+
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+
+class SaveStravaTokenUseCase(
+    private val repository: StravaTokenStorageRepository,
+) {
+    suspend operator fun invoke(accessToken: String, refreshToken: String, expiresAt: Long) {
+        repository.saveToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            expiresAt = expiresAt,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/common/navigation/NavigationRoot.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.serialization.SavedStateConfiguration
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
 import com.majotyler.hiittimer.domain.model.Workout
 import com.majotyler.hiittimer.platform.UrlOpener
 import com.majotyler.hiittimer.presentation.common.ui.HiitAppTheme
@@ -34,11 +35,13 @@ import kotlin.uuid.Uuid
 fun NavigationRoot(
     urlOpener: UrlOpener,
     stravaAccessCode: String?,
+    stravaTokenStorageRepository: StravaTokenStorageRepository,
 ) {
     HiitAppTheme {
         HiitNavDisplay(
             urlOpener = urlOpener,
             stravaAccessCode = stravaAccessCode,
+            stravaTokenStorageRepository = stravaTokenStorageRepository,
         )
     }
 }
@@ -48,6 +51,7 @@ fun NavigationRoot(
 private fun HiitNavDisplay(
     urlOpener: UrlOpener,
     stravaAccessCode: String?,
+    stravaTokenStorageRepository: StravaTokenStorageRepository,
 ) {
 
     val resultBus = remember { ResultEventBus() }
@@ -107,6 +111,7 @@ private fun HiitNavDisplay(
                         }
                     },
                     stravaAccessCode = stravaAccessCode,
+                    stravaTokenStorageRepository = stravaTokenStorageRepository,
                 )
 
                 HomeScreen(

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
@@ -7,9 +7,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewModelScope
 import com.majotyler.hiittimer.platform.UrlOpener
 
 @Composable
@@ -18,6 +19,8 @@ fun HomeScreen(
     viewModel: HomeViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val showCreateActivityButton by viewModel.showCreateActivityButton.collectAsState()
+
     LaunchedEffect(Unit) {
         viewModel.openUrl.collect { url ->
             urlOpener.openUrl(url = url)
@@ -45,7 +48,7 @@ fun HomeScreen(
             Text(text = "Connect with Strava")
         }
 
-        if (viewModel.showCreateActivityButton) {
+        if (showCreateActivityButton) {
             Button(
                 onClick = {
                     viewModel.onEvent(event = HomeViewEvent.ClickedCreateStravaActivity)

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
+import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
 import com.majotyler.hiittimer.network.HttpClientFactory
 import com.majotyler.hiittimer.presentation.common.navigation.Router
@@ -20,6 +21,7 @@ class HomeViewModel(
     private val stravaAccessCode: String?,
     private val getStoredStravaTokenUseCase: GetStoredStravaTokenUseCase,
     private val saveStravaTokenUseCase: SaveStravaTokenUseCase,
+    private val refreshStravaTokenUseCase: RefreshStravaTokenUseCase,
 ) : ViewModel() {
 
     private val _openUrl = MutableSharedFlow<String>()
@@ -51,10 +53,16 @@ class HomeViewModel(
             when {
                 storedToken != null && storedToken.expiresAt > nowSeconds -> {
                     println("Stored token is valid, expires in ${storedToken.expiresAt - nowSeconds}s")
-                    println("access_token (encrypted): ${storedToken.accessToken}")
+                    println("access_token: ${storedToken.accessToken}")
                 }
                 storedToken != null -> {
-                    println("Stored token is expired (expired ${nowSeconds - storedToken.expiresAt}s ago)")
+                    println("Stored token is expired (expired ${nowSeconds - storedToken.expiresAt}s ago), refreshing...")
+                    try {
+                        refreshStravaTokenUseCase(refreshToken = storedToken.refreshToken)
+                        println("Token refresh successful")
+                    } catch (e: Exception) {
+                        println("Token refresh error: $e")
+                    }
                 }
                 else -> {
                     println("No stored token found")
@@ -65,8 +73,8 @@ class HomeViewModel(
                 try {
                     println("Exchanging OAuth code for token via proxy...")
                     val result = stravaRepository.getAccessToken(code = stravaAccessCode)
-                    println("access_token (encrypted): ${result.accessToken}")
-                    println("refresh_token (encrypted): ${result.refreshToken}")
+                    println("access_token: ${result.accessToken}")
+                    println("refresh_token: ${result.refreshToken}")
                     println("token_type: ${result.tokenType}")
                     println("expires_at: ${result.expiresAt}")
                     println("expires_in: ${result.expiresIn}")

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
@@ -6,15 +6,20 @@ import io.ktor.http.*
 import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
+import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
+import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
 import com.majotyler.hiittimer.network.HttpClientFactory
 import com.majotyler.hiittimer.presentation.common.navigation.Router
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 
 class HomeViewModel(
     private val router: Router<HomeDestination>,
     private val stravaAccessCode: String?,
+    private val getStoredStravaTokenUseCase: GetStoredStravaTokenUseCase,
+    private val saveStravaTokenUseCase: SaveStravaTokenUseCase,
 ) : ViewModel() {
 
     private val _openUrl = MutableSharedFlow<String>()
@@ -39,15 +44,37 @@ class HomeViewModel(
     }
 
     init {
-        if (stravaAccessCode != null) {
-            viewModelScope.launch {
+        viewModelScope.launch {
+            val storedToken = getStoredStravaTokenUseCase()
+            val nowSeconds = Clock.System.now().epochSeconds
+
+            when {
+                storedToken != null && storedToken.expiresAt > nowSeconds -> {
+                    println("Stored token is valid, expires in ${storedToken.expiresAt - nowSeconds}s")
+                    println("access_token (encrypted): ${storedToken.accessToken}")
+                }
+                storedToken != null -> {
+                    println("Stored token is expired (expired ${nowSeconds - storedToken.expiresAt}s ago)")
+                }
+                else -> {
+                    println("No stored token found")
+                }
+            }
+
+            if (stravaAccessCode != null) {
                 try {
+                    println("Exchanging OAuth code for token via proxy...")
                     val result = stravaRepository.getAccessToken(code = stravaAccessCode)
                     println("access_token (encrypted): ${result.accessToken}")
                     println("refresh_token (encrypted): ${result.refreshToken}")
                     println("token_type: ${result.tokenType}")
                     println("expires_at: ${result.expiresAt}")
                     println("expires_in: ${result.expiresIn}")
+                    saveStravaTokenUseCase(
+                        accessToken = result.accessToken,
+                        refreshToken = result.refreshToken,
+                        expiresAt = result.expiresAt,
+                    )
                 } catch (e: Exception) {
                     println("Token exchange error: $e")
                 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
@@ -3,47 +3,34 @@ package com.majotyler.hiittimer.presentation.homeScreen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.ktor.http.*
-import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
-import com.majotyler.hiittimer.network.HttpClientFactory
 import com.majotyler.hiittimer.presentation.common.navigation.Router
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 
 class HomeViewModel(
     private val router: Router<HomeDestination>,
     private val stravaAccessCode: String?,
+    private val stravaRepository: StravaRepository,
     private val getStoredStravaTokenUseCase: GetStoredStravaTokenUseCase,
     private val saveStravaTokenUseCase: SaveStravaTokenUseCase,
     private val refreshStravaTokenUseCase: RefreshStravaTokenUseCase,
+    private val createStravaActivityUseCase: CreateStravaActivityUseCase,
 ) : ViewModel() {
 
     private val _openUrl = MutableSharedFlow<String>()
     val openUrl = _openUrl.asSharedFlow()
 
-    // TODO This is temporary to show something to create a Strava Activity
-    val showCreateActivityButton = stravaAccessCode != null
-
-    private val httpClient by lazy {
-        HttpClientFactory.create()
-    }
-
-    private val stravaApi: StravaApi by lazy {
-        StravaApi(httpClient)
-    }
-
-    private val stravaRepository by lazy {
-        StravaRepository(stravaApi)
-    }
-    private val createStravaActivityUseCase by lazy {
-        CreateStravaActivityUseCase()
-    }
+    private val _showCreateActivityButton = MutableStateFlow(false)
+    val showCreateActivityButton = _showCreateActivityButton.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -54,12 +41,14 @@ class HomeViewModel(
                 storedToken != null && storedToken.expiresAt > nowSeconds -> {
                     println("Stored token is valid, expires in ${storedToken.expiresAt - nowSeconds}s")
                     println("access_token: ${storedToken.accessToken}")
+                    _showCreateActivityButton.value = true
                 }
                 storedToken != null -> {
                     println("Stored token is expired (expired ${nowSeconds - storedToken.expiresAt}s ago), refreshing...")
                     try {
                         refreshStravaTokenUseCase(refreshToken = storedToken.refreshToken)
                         println("Token refresh successful")
+                        _showCreateActivityButton.value = true
                     } catch (e: Exception) {
                         println("Token refresh error: $e")
                     }
@@ -83,6 +72,7 @@ class HomeViewModel(
                         refreshToken = result.refreshToken,
                         expiresAt = result.expiresAt,
                     )
+                    _showCreateActivityButton.value = true
                 } catch (e: Exception) {
                     println("Token exchange error: $e")
                 }
@@ -106,7 +96,17 @@ class HomeViewModel(
 
     private fun onClickedCreateStravaActivity() {
         viewModelScope.launch {
-            createStravaActivityUseCase()
+            try {
+                createStravaActivityUseCase(
+                    name = "HIIT Timer Workout",
+                    sportType = "HighIntensityIntervalTraining",
+                    startDateLocal = "2026-04-25T12:00:00Z",
+                    elapsedTime = 1800,
+                )
+                println("Create activity successful")
+            } catch (e: Exception) {
+                println("Create activity error: $e")
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
@@ -3,16 +3,22 @@ package com.majotyler.hiittimer.presentation.homeScreen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
+import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
 import kotlin.reflect.KClass
 
 class HomeViewModelFactory(
     private val router: (HomeDestination) -> Unit,
     private val stravaAccessCode: String?,
+    private val stravaTokenStorageRepository: StravaTokenStorageRepository,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
         return HomeViewModel(
             router = router,
             stravaAccessCode = stravaAccessCode,
+            getStoredStravaTokenUseCase = GetStoredStravaTokenUseCase(repository = stravaTokenStorageRepository),
+            saveStravaTokenUseCase = SaveStravaTokenUseCase(repository = stravaTokenStorageRepository),
         ) as T
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
@@ -22,9 +23,14 @@ class HomeViewModelFactory(
         return HomeViewModel(
             router = router,
             stravaAccessCode = stravaAccessCode,
+            stravaRepository = stravaRepository,
             getStoredStravaTokenUseCase = GetStoredStravaTokenUseCase(repository = stravaTokenStorageRepository),
             saveStravaTokenUseCase = SaveStravaTokenUseCase(repository = stravaTokenStorageRepository),
             refreshStravaTokenUseCase = RefreshStravaTokenUseCase(
+                stravaRepository = stravaRepository,
+                stravaTokenStorageRepository = stravaTokenStorageRepository,
+            ),
+            createStravaActivityUseCase = CreateStravaActivityUseCase(
                 stravaRepository = stravaRepository,
                 stravaTokenStorageRepository = stravaTokenStorageRepository,
             ),

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
@@ -3,9 +3,13 @@ package com.majotyler.hiittimer.presentation.homeScreen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.majotyler.hiittimer.data.api.StravaApi
+import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
+import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
+import com.majotyler.hiittimer.network.HttpClientFactory
 import kotlin.reflect.KClass
 
 class HomeViewModelFactory(
@@ -14,11 +18,16 @@ class HomeViewModelFactory(
     private val stravaTokenStorageRepository: StravaTokenStorageRepository,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        val stravaRepository = StravaRepository(api = StravaApi(client = HttpClientFactory.create()))
         return HomeViewModel(
             router = router,
             stravaAccessCode = stravaAccessCode,
             getStoredStravaTokenUseCase = GetStoredStravaTokenUseCase(repository = stravaTokenStorageRepository),
             saveStravaTokenUseCase = SaveStravaTokenUseCase(repository = stravaTokenStorageRepository),
+            refreshStravaTokenUseCase = RefreshStravaTokenUseCase(
+                stravaRepository = stravaRepository,
+                stravaTokenStorageRepository = stravaTokenStorageRepository,
+            ),
         ) as T
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.11.2"
+androidx-security = "1.1.0-alpha06"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
@@ -26,6 +27,7 @@ androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "an
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "cmpNavigation3" }


### PR DESCRIPTION
## Summary
- Adds \`AndroidStravaTokenStorageRepository\` backed by \`EncryptedSharedPreferences\` (AES256-GCM via Android Keystore)
- After the proxy exchange, the encrypted \`access_token\`, \`refresh_token\`, and \`expires_at\` are persisted to storage
- Platform-agnostic \`StravaTokenStorageRepository\` interface in commonMain; Android implementation in androidMain
- iOS storage is a TODO for a future PR

## PR Series
1. **[#49](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/49)** — Route Strava OAuth token exchange through Cloudflare Worker proxy
2. **[#50](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/50)** — Encrypt Strava tokens in proxy before returning to app
3. **[#51](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/51)** — Store encrypted Strava tokens in Android Keystore ← you are here
4. **[#52](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/52)** — Refresh expired Strava tokens via proxy
5. **[#53](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/53)** — Route create activity through Cloudflare Worker proxy