### PR TITLE
Route create activity through Cloudflare Worker proxy

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/api/StravaApi.kt
@@ -3,68 +3,69 @@ package com.majotyler.hiittimer.data.api
 import com.majotyler.hiittimer.data.dto.StravaAuthenticationDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.forms.FormDataContent
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.Parameters
 import io.ktor.http.contentType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 class StravaApi(private val client: HttpClient) {
-    suspend fun getAccessTokenViaProxy(
+    suspend fun getAccessToken(
         code: String,
     ): StravaAuthenticationDto {
-        val response = client.post(urlString = ProxyEndpoints.OAUTH_TOKEN) {
+        val response = client.post(urlString = Endpoints.OAUTH_TOKEN) {
             contentType(ContentType.Application.Json)
             setBody(mapOf("code" to code))
         }
-        println("Proxy token exchange status: ${response.status}")
+        println("Token exchange status: ${response.status}")
         return response.body()
     }
 
-    suspend fun refreshAccessTokenViaProxy(
+    suspend fun refreshAccessToken(
         refreshToken: String,
     ): StravaAuthenticationDto {
-        val response = client.post(urlString = ProxyEndpoints.OAUTH_REFRESH) {
+        val response = client.post(urlString = Endpoints.OAUTH_REFRESH) {
             contentType(ContentType.Application.Json)
             setBody(mapOf("refresh_token" to refreshToken))
         }
-        println("Proxy token refresh status: ${response.status}")
+        println("Token refresh status: ${response.status}")
         return response.body()
     }
 
     suspend fun createActivity(
         accessToken: String,
         name: String,
-        type: String,
+        sportType: String,
         startDateLocal: String,
         elapsedTime: Int,
     ) {
-        return client.post(urlString = StravaEndpoints.ACTIVITIES) {
-            header(key = HttpHeaders.Authorization, value = "Bearer $accessToken")
-            setBody(
-                body = FormDataContent(
-                    formData = Parameters.build {
-                        append(name = "name", value = name)
-                        append(name = "sport_type", value = type)
-                        append(name = "start_date_local", value = startDateLocal)
-                        append(name = "elapsed_time", value = elapsedTime.toString())
-                    }
-                )
-            )
-        }.body()
+        val response = client.post(urlString = Endpoints.CREATE_ACTIVITY) {
+            contentType(ContentType.Application.Json)
+            setBody(CreateActivityRequest(
+                accessToken = accessToken,
+                name = name,
+                sportType = sportType,
+                startDateLocal = startDateLocal,
+                elapsedTime = elapsedTime,
+            ))
+        }
+        println("Create activity status: ${response.status}")
     }
 }
 
-private object StravaEndpoints {
-    const val BASE_URL = "https://www.strava.com"
-    const val ACTIVITIES = "$BASE_URL/api/v3/activities"
-}
+@Serializable
+private data class CreateActivityRequest(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("name") val name: String,
+    @SerialName("sport_type") val sportType: String,
+    @SerialName("start_date_local") val startDateLocal: String,
+    @SerialName("elapsed_time") val elapsedTime: Int,
+)
 
-private object ProxyEndpoints {
+private object Endpoints {
     const val BASE_URL = "https://strava-token-proxy.hiit-timer-app.workers.dev"
     const val OAUTH_TOKEN = BASE_URL
     const val OAUTH_REFRESH = "$BASE_URL/refresh"
+    const val CREATE_ACTIVITY = "$BASE_URL/activity"
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/data/repository/StravaRepository.kt
@@ -9,22 +9,28 @@ class StravaRepository(
     suspend fun getAccessToken(
         code: String,
     ): StravaAuthenticationDto {
-        return api.getAccessTokenViaProxy(code = code)
+        return api.getAccessToken(code = code)
     }
 
     suspend fun refreshAccessToken(
         refreshToken: String,
     ): StravaAuthenticationDto {
-        return api.refreshAccessTokenViaProxy(refreshToken = refreshToken)
+        return api.refreshAccessToken(refreshToken = refreshToken)
     }
 
     suspend fun createActivity(
         accessToken: String,
         name: String,
-        type: String,
+        sportType: String,
         startDateLocal: String,
         elapsedTime: Int,
     ) {
-        return api.createActivity(accessToken, name, type, startDateLocal, elapsedTime)
+        api.createActivity(
+            accessToken = accessToken,
+            name = name,
+            sportType = sportType,
+            startDateLocal = startDateLocal,
+            elapsedTime = elapsedTime,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/domain/usecase/CreateStravaActivityUseCase.kt
@@ -1,7 +1,26 @@
 package com.majotyler.hiittimer.domain.usecase
 
-class CreateStravaActivityUseCase {
-    suspend operator fun invoke() {
-        // TODO: createActivity needs to move to the worker once full proxy is built
+import com.majotyler.hiittimer.data.repository.StravaRepository
+import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+
+class CreateStravaActivityUseCase(
+    private val stravaRepository: StravaRepository,
+    private val stravaTokenStorageRepository: StravaTokenStorageRepository,
+) {
+    suspend operator fun invoke(
+        name: String,
+        sportType: String,
+        startDateLocal: String,
+        elapsedTime: Int,
+    ) {
+        val token = stravaTokenStorageRepository.getStoredToken()
+            ?: error("No stored Strava token")
+        stravaRepository.createActivity(
+            accessToken = token.accessToken,
+            name = name,
+            sportType = sportType,
+            startDateLocal = startDateLocal,
+            elapsedTime = elapsedTime,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeScreen.kt
@@ -7,9 +7,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewModelScope
 import com.majotyler.hiittimer.platform.UrlOpener
 
 @Composable
@@ -18,6 +19,8 @@ fun HomeScreen(
     viewModel: HomeViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val showCreateActivityButton by viewModel.showCreateActivityButton.collectAsState()
+
     LaunchedEffect(Unit) {
         viewModel.openUrl.collect { url ->
             urlOpener.openUrl(url = url)
@@ -45,7 +48,7 @@ fun HomeScreen(
             Text(text = "Connect with Strava")
         }
 
-        if (viewModel.showCreateActivityButton) {
+        if (showCreateActivityButton) {
             Button(
                 onClick = {
                     viewModel.onEvent(event = HomeViewEvent.ClickedCreateStravaActivity)

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModel.kt
@@ -3,47 +3,34 @@ package com.majotyler.hiittimer.presentation.homeScreen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.ktor.http.*
-import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
-import com.majotyler.hiittimer.network.HttpClientFactory
 import com.majotyler.hiittimer.presentation.common.navigation.Router
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 
 class HomeViewModel(
     private val router: Router<HomeDestination>,
     private val stravaAccessCode: String?,
+    private val stravaRepository: StravaRepository,
     private val getStoredStravaTokenUseCase: GetStoredStravaTokenUseCase,
     private val saveStravaTokenUseCase: SaveStravaTokenUseCase,
     private val refreshStravaTokenUseCase: RefreshStravaTokenUseCase,
+    private val createStravaActivityUseCase: CreateStravaActivityUseCase,
 ) : ViewModel() {
 
     private val _openUrl = MutableSharedFlow<String>()
     val openUrl = _openUrl.asSharedFlow()
 
-    // TODO This is temporary to show something to create a Strava Activity
-    val showCreateActivityButton = stravaAccessCode != null
-
-    private val httpClient by lazy {
-        HttpClientFactory.create()
-    }
-
-    private val stravaApi: StravaApi by lazy {
-        StravaApi(httpClient)
-    }
-
-    private val stravaRepository by lazy {
-        StravaRepository(stravaApi)
-    }
-    private val createStravaActivityUseCase by lazy {
-        CreateStravaActivityUseCase()
-    }
+    private val _showCreateActivityButton = MutableStateFlow(false)
+    val showCreateActivityButton = _showCreateActivityButton.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -54,12 +41,14 @@ class HomeViewModel(
                 storedToken != null && storedToken.expiresAt > nowSeconds -> {
                     println("Stored token is valid, expires in ${storedToken.expiresAt - nowSeconds}s")
                     println("access_token: ${storedToken.accessToken}")
+                    _showCreateActivityButton.value = true
                 }
                 storedToken != null -> {
                     println("Stored token is expired (expired ${nowSeconds - storedToken.expiresAt}s ago), refreshing...")
                     try {
                         refreshStravaTokenUseCase(refreshToken = storedToken.refreshToken)
                         println("Token refresh successful")
+                        _showCreateActivityButton.value = true
                     } catch (e: Exception) {
                         println("Token refresh error: $e")
                     }
@@ -83,6 +72,7 @@ class HomeViewModel(
                         refreshToken = result.refreshToken,
                         expiresAt = result.expiresAt,
                     )
+                    _showCreateActivityButton.value = true
                 } catch (e: Exception) {
                     println("Token exchange error: $e")
                 }
@@ -106,7 +96,17 @@ class HomeViewModel(
 
     private fun onClickedCreateStravaActivity() {
         viewModelScope.launch {
-            createStravaActivityUseCase()
+            try {
+                createStravaActivityUseCase(
+                    name = "HIIT Timer Workout",
+                    sportType = "HighIntensityIntervalTraining",
+                    startDateLocal = "2026-04-25T12:00:00Z",
+                    elapsedTime = 1800,
+                )
+                println("Create activity successful")
+            } catch (e: Exception) {
+                println("Create activity error: $e")
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/majotyler/hiittimer/presentation/homeScreen/HomeViewModelFactory.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.majotyler.hiittimer.data.api.StravaApi
 import com.majotyler.hiittimer.data.repository.StravaRepository
 import com.majotyler.hiittimer.data.repository.StravaTokenStorageRepository
+import com.majotyler.hiittimer.domain.usecase.CreateStravaActivityUseCase
 import com.majotyler.hiittimer.domain.usecase.GetStoredStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.RefreshStravaTokenUseCase
 import com.majotyler.hiittimer.domain.usecase.SaveStravaTokenUseCase
@@ -22,9 +23,14 @@ class HomeViewModelFactory(
         return HomeViewModel(
             router = router,
             stravaAccessCode = stravaAccessCode,
+            stravaRepository = stravaRepository,
             getStoredStravaTokenUseCase = GetStoredStravaTokenUseCase(repository = stravaTokenStorageRepository),
             saveStravaTokenUseCase = SaveStravaTokenUseCase(repository = stravaTokenStorageRepository),
             refreshStravaTokenUseCase = RefreshStravaTokenUseCase(
+                stravaRepository = stravaRepository,
+                stravaTokenStorageRepository = stravaTokenStorageRepository,
+            ),
+            createStravaActivityUseCase = CreateStravaActivityUseCase(
                 stravaRepository = stravaRepository,
                 stravaTokenStorageRepository = stravaTokenStorageRepository,
             ),


### PR DESCRIPTION
## Summary
- Adds \`/activity\` route to Cloudflare Worker: decrypts the stored access token, forwards the create activity request to Strava, returns Strava's response as-is
- Replaces direct Strava API call in \`StravaApi\` with \`createActivityViaProxy\`; removes \`StravaEndpoints\` — no more direct Strava calls from the app
- \`CreateStravaActivityUseCase\` now reads the stored token and calls the repository instead of being a stub
- \`HomeViewModel\` receives \`createStravaActivityUseCase\` as a constructor param (consistent with other use cases); factory constructs and injects it

## PR Series
1. **[#49](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/49)** — Route Strava OAuth token exchange through Cloudflare Worker proxy
2. **[#50](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/50)** — Encrypt Strava tokens in proxy before returning to app
3. **[#51](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/51)** — Store encrypted Strava tokens in Android Keystore
4. **[#52](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/52)** — Refresh expired Strava tokens via proxy
5. **[#53](https://github.com/Tyler-Lopez/hiit-timer-kmp/pull/53)** — Route create activity through Cloudflare Worker proxy ← you are here